### PR TITLE
poc Infracost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Terraform artifacts
+.terraform.lock.hcl
+.terraform

--- a/infracost-usage.yml
+++ b/infracost-usage.yml
@@ -1,0 +1,352 @@
+## You can use this file to define resource usage estimates for Infracost to use when calculating
+## the cost of usage-based resource, such as AWS Lambda.
+## `infracost --usage-file /path/to/infracost-usage.yml [other flags]`
+## See https://github.com/infracost/infracost/blob/master/infracost-usage-example.yml for available options.
+version: v0.1
+resource_usage:
+
+  # Note that we're working on adding all of the supported resources (https://www.infracost.io/docs/supported_resources) to
+  # the usage file feature. Please watch https://github.com/infracost/infracost/issues/421 for updates.
+
+  #
+  # The usage file also supports specifying usage for resources inside modules,
+  # by specifying the full path to the resource. This is the same value as Infracost
+  # outputs in the NAME column , e.g.:
+  #
+  # module.my_module.aws_dynamodb_table.my_table:
+  #   storage_gb: 1000
+  # module.lambda_function.aws_lambda_function.this[0]:
+  #   monthly_requests: 20000
+  #   request_duration_ms: 600
+
+  #
+  # Terraform AWS resources
+  #
+  aws_acmpca_certificate_authority.my_private_ca:
+    monthly_requests: 20000 # Monthly private certificate requests.
+
+  aws_api_gateway_rest_api.my_rest_api:
+    monthly_requests:  100000000 # Monthly requests to the Rest API Gateway.
+
+  aws_apigatewayv2_api.my_v2_api:
+    monthly_requests: 100000000       # Monthly requests to the HTTP API Gateway.
+    request_size_kb: 512              # Average request size sent to the HTTP API Gateway in KB. Requests are metered in 512KB increments, maximum size is 10MB.
+    monthly_messages: 1500000000      # Monthly number of messages sent to the Websocket API Gateway.
+    message_size_kb: 32               # Average size of the messages sent to the Websocket API Gateway in KB. Messages are metered in 32 KB increments, maximum size is 128KB.
+    monthly_connection_mins: 10000000 # Monthly total connection minutes to Websockets.
+
+  aws_cloudwatch_event_bus.my_events:
+    monthly_custom_events: 1000000            # Monthly custom events published. Each 64 KB chunk of payload is billed as 1 event.
+    monthly_third_party_events: 2000000       # Monthly third-party and cross-account events published. Each 64 KB chunk of payload is billed as 1 event.
+    monthly_archive_processing_gb: 100        # Monthly archive event processing in GB. 
+    archive_storage_gb: 200                   # Archive storage used for event replay in GB.
+    monthly_schema_discovery_events: 1000000  # Monthly events ingested for schema discovery. Each 8 KB chunk of payload is billed as 1 event.
+
+  aws_cloudwatch_log_group.my_log_group:
+    storage_gb: 1000               # Total data stored by CloudWatch logs in GB.
+    monthly_data_ingested_gb: 1000 # Monthly data ingested by CloudWatch logs in GB.
+    monthly_data_scanned_gb: 200   # Monthly data scanned by CloudWatch logs insights in GB.
+
+  aws_codebuild_project.my_project: 
+    monthly_build_mins: 10000 # Monthly total duration of builds in minutes. Each build is rounded up to the nearest minute.
+    
+  aws_config_config_rule.my_config:
+    monthly_rule_evaluations: 1000000 # Monthly config rule evaluations.
+
+  aws_config_configuration_recorder.my_config:
+    monthly_config_items: 10000        # Monthly config item records.
+    monthly_custom_config_items: 20000 # Monthly custom config item records.
+
+  aws_config_organization_custom_rule.my_config:
+    monthly_rule_evaluations: 300000 # Monthly config rule evaluations.
+
+  aws_config_organization_managed_rule.my_config:
+    monthly_rule_evaluations: 10000 # Monthly config rule evaluations.
+
+  aws_data_transfer.my_region:
+    region: ap-northeast-1                      # Region the data transfer is originating from.
+    monthly_intra_region_gb: 500                # Monthly data transferred between availability zones in the region.
+    monthly_outbound_us_east_to_us_east_gb: 0 # Monthly data transferred between US east regions. NOTE: this is only valid if the region is a us-east region.
+    monthly_outbound_other_region_gb: 750       # Monthly data transferred to other AWS regions.
+    monthly_outbound_internet_gb: 500          # Monthly data transferred to the Internet.
+
+  aws_docdb_cluster_instance.my_db:
+    data_storage_gb: 5            # Total storage for cluster in GB.
+    backup_storage_gb: 20         # Amount of backup storage that is in excess of 100% of the storage size for the cluster in GB.
+    monthly_io_request: 100000000 # Monthly number of input/output requests for cluster.
+    monthly_cpu_credit_hours: 100 # Monthly CPU credits used over the instance baseline in vCPU-hours, only applicable for T3 instances. 
+
+  aws_dx_connection.my_dx_connection:
+    monthly_outbound_region_to_dx_location_gb: 100 # Monthly outbound data transferred from AWS region to DX location in GB.
+    dx_virtual_interface_type: private             # Interface type impacts outbound data transfer costs over DX, can be: private, public.
+    dx_connection_type: dedicated                  # Connection type impacts the per-port hourly price, can be: dedicated, hosted.
+
+  aws_dx_gateway_association.my_gateway:
+    monthly_data_processed_gb: 100 # Monthly data processed by the DX gateway association per month in GB.
+
+  aws_dynamodb_table.my_table:
+    monthly_write_request_units: 3000000  # Monthly write request units in (used for on-demand DynamoDB).
+    monthly_read_request_units: 8000000   # Monthly read request units in (used for on-demand DynamoDB).
+    storage_gb: 230                       # Total storage for tables in GB.
+    pitr_backup_storage_gb: 2300          # Total storage for Point-In-Time Recovery (PITR) backups in GB.
+    on_demand_backup_storage_gb: 460      # Total storage for on-demand backups in GB.
+    monthly_data_restored_gb: 230         # Monthly size of restored data in GB.
+    monthly_streams_read_request_units: 2 # Monthly streams read request units.
+
+  aws_ebs_snapshot.my_snapshot:
+    monthly_list_block_requests: 1000000  # Monthly number of ListChangedBlocks and ListSnapshotBlocks requests.
+    monthly_get_block_requests: 100000    # Monthly number of GetSnapshotBlock requests (block size is 512KiB).
+    monthly_put_block_requests: 100000    # Monthly number of PutSnapshotBlock requests (block size is 512KiB).
+
+  aws_ebs_volume.my_standard_volume:
+    monthly_standard_io_requests: 10000000 # Monthly I/O requests for standard volume (Magnetic storage).
+
+  aws_ec2_transit_gateway_vpc_attachment.my_vpc_attachment:
+    monthly_data_processed_gb: 100 # Monthly data processed by the EC2 transit gateway attachment(s) in GB.
+
+  aws_ecr_repository.my_repository:
+    storage_gb: 1 # Total size of ECR repository in GB.
+
+  aws_efs_file_system.my_file_system:
+    storage_gb: 230                         # Total storage for Standard class in GB.
+    infrequent_access_storage_gb: 100       # Total storage for Infrequent Access class in GB.
+    monthly_infrequent_access_read_gb: 50   # Monthly infrequent access read requests in GB.
+    monthly_infrequent_access_write_gb: 100 # Monthly infrequent access write requests in GB.
+
+  aws_elasticache_cluster.my_redis_snapshot:
+    snapshot_storage_size_gb: 10000 # Size of Redis snapshots in GB. 
+
+  aws_elb.my_elb:
+    monthly_data_processed_gb: 500 # Monthly data processed by a Classic Load Balancer in GB.
+
+  aws_instance.windows_instance:
+    operating_system: windows # Override the operating system of the instance, can be: windows, suse, rhel.
+
+  aws_fsx_windows_file_system.my_system:
+    backup_storage_gb: 10000 # Total storage used for backups in GB.
+
+  aws_lambda_function.my_function:
+    monthly_requests: 100000 # Monthly requests to the Lambda function.
+    request_duration_ms: 500 # Average duration of each request in milliseconds.
+
+  # The same can be used for the aws_alb resource too.
+  aws_lb.my_lb:
+    new_connections: 10000    # Number of newly established connections per second on average.
+    active_connections: 10000 # Number of active connections per minute on average.
+    processed_bytes_gb: 1000  # The number of bytes processed by the load balancer for HTTP(S) requests and responses in GB.
+    rule_evaluations: 10000   # The product of number of rules processed by the load balancer and the request rate.
+
+  aws_nat_gateway.my_nat_gateway:
+    monthly_data_processed_gb: 10 # Monthly data processed by the NAT Gateway in GB.
+
+  aws_route53_record.my_record:
+    monthly_standard_queries: 1100000000      # Monthly number of Standard queries.
+    monthly_latency_based_queries: 1200000000 # Monthly number of Latency Based Routing queries.
+    monthly_geo_queries: 1500000000           # Monthly number of Geo DNS and Geoproximity queries.
+
+  aws_route53_resolver_endpoint.my_endpoint:
+    monthly_queries: 20000000000 # Monthly number of DNS queries processed through the endpoints.
+
+  aws_s3_bucket_analytics_configuration.my_config:
+    monthly_monitored_objects: 10000000 # Monthly number of monitored objects by S3 Analytics Storage Class Analysis.
+
+  aws_s3_bucket_inventory.my_inventory:
+    monthly_listed_objects: 100000000 # Monthly number of listed objects.
+
+  aws_s3_bucket.my_bucket:
+    object_tags: 10000000 # Total object tags.
+    standard: # Usages of S3 Standard:
+      storage_gb: 10000 # Total storage in GB.
+      monthly_tier_1_requests: 1000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 100000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_select_data_scanned_gb: 10000 # Monthly data scanned by S3 Select in GB.
+      monthly_select_data_returned_gb: 1000 # Monthly data returned by S3 Select in GB.
+    intelligent_tiering: # Usages of S3 Intelligent - Tiering:
+      frequent_access_storage_gb: 20000 # Total storage for Frequent Access Tier in GB.
+      infrequent_access_storage_gb: 20000 # Total storage for Infrequent Access Tier in GB.
+      monitored_objects: 2000 # Total objects monitored by the Intelligent Tiering.
+      monthly_tier_1_requests: 2000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 200000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_lifecycle_transition_requests: 200000 # Monthly Lifecycle Transition requests.
+      monthly_select_data_scanned_gb: 20000 # Monthly data scanned by S3 Select in GB.
+      monthly_select_data_returned_gb: 2000 # Monthly data returned by S3 Select in GB.
+      early_delete_gb: 200000 # If an archive is deleted within 1 months of being uploaded, you will be charged an early deletion fee per GB.
+    standard_infrequent_access: # Usages of S3 Standard - Infrequent Access:
+      storage_gb: 30000 # Total storage in GB.
+      monthly_tier_1_requests: 3000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 300000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_lifecycle_transition_requests: 300000 # Monthly Lifecycle Transition requests.
+      monthly_retrieval_gb: 30000 # Monthly data retrievals in GB
+      monthly_select_data_scanned_gb: 30000 # Monthly data scanned by S3 Select in GB.
+      monthly_select_data_returned_gb: 3000 # Monthly data returned by S3 Select in GB.
+    one_zone_infrequent_access: # Usages of S3 One Zone - Infrequent Access:
+      storage_gb: 40000 # Total storage in GB.
+      monthly_tier_1_requests: 4000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 400000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_lifecycle_transition_requests: 400000 # Monthly Lifecycle Transition requests.
+      monthly_retrieval_gb: 40000 # Monthly data retrievals in GB
+      monthly_select_data_scanned_gb: 40000 # Monthly data scanned by S3 Select in GB.
+      monthly_select_data_returned_gb: 4000 # Monthly data returned by S3 Select in GB.
+    glacier: # Usages of S3 Glacier:
+      storage_gb: 50000 # Total storage in GB.
+      monthly_tier_1_requests: 5000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 500000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_lifecycle_transition_requests: 500000 # Monthly Lifecycle Transition requests.
+      monthly_standard_select_data_scanned_gb: 500000 # Monthly data scanned by S3 Select in GB (for standard level of S3 Glacier).
+      monthly_standard_select_data_returned_gb: 500000 # Monthly data returned by S3 Select in GB (for standard level of S3 Glacier).
+      monthly_bulk_select_data_scanned_gb: 500000 # Monthly data scanned by S3 Select in GB (for bulk level of S3 Glacier)
+      monthly_bulk_select_data_returned_gb: 500000 # Monthly data returned by S3 Select in GB (for bulk level of S3 Glacier)
+      monthly_expedited_select_data_scanned_gb: 500000 # Monthly data scanned by S3 Select in GB (for expedited level of S3 Glacier)
+      monthly_expedited_select_data_returned_gb: 500000 # Monthly data returned by S3 Select in GB (for expedited level of S3 Glacier)
+      monthly_standard_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for standard level of S3 Glacier).
+      monthly_bulk_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
+      monthly_expedited_data_retrieval_requests: 500000 # Monthly data Retrieval requests (for expedited level of S3 Glacier).
+      monthly_standard_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for standard level of S3 Glacier).
+      monthly_bulk_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
+      monthly_expedited_data_retrieval_gb: 5000 # Monthly data retrievals in GB (for expedited level of S3 Glacier).
+      early_delete_gb: 500000 # If an archive is deleted within 3 months of being uploaded, you will be charged an early deletion fee per GB.
+    glacier_deep_archive: # Usages of S3 Glacier Deep Archive:
+      storage_gb: 60000 # Total storage in GB.
+      monthly_tier_1_requests: 6000000 # Monthly PUT, COPY, POST, LIST requests (Tier 1).
+      monthly_tier_2_requests: 600000 # Monthly GET, SELECT, and all other requests (Tier 2).
+      monthly_lifecycle_transition_requests: 600000 # Monthly Lifecycle Transition requests.
+      monthly_standard_data_retrieval_requests: 600000 # Monthly data Retrieval requests (for standard level of S3 Glacier).
+      monthly_bulk_data_retrieval_requests: 600000 # Monthly data Retrieval requests (for bulk level of S3 Glacier).
+      monthly_standard_data_retrieval_gb: 6000 # Monthly data retrievals in GB (for standard level of S3 Glacier).
+      monthly_bulk_data_retrieval_gb: 6000 # Monthly data retrievals in GB (for bulk level of S3 Glacier).
+      early_delete_gb: 600000 # If an archive is deleted within 6 months of being uploaded, you will be charged an early deletion fee per GB.
+
+  aws_secretsmanager_secret.my_secret:
+    monthly_requests: 1000000 # Monthly API requests to Secrets Manager.
+
+  aws_sns_topic.my_sns_topic:
+    monthly_requests: 1000000 # Monthly requests to SNS.
+    request_size_kb: 64       # Size of requests to SNS, billed in 64KB chunks. So 1M requests at 128KB uses 2M requests.
+
+  aws_sns_topic_subscription.my_topic_subscription:
+    monthly_requests: 1000000 # Monthly requests to SNS.
+    request_size_kb: 64       # Size of requests to SNS, billed in 64KB chunks. So 1M requests at 128KB uses 2M requests.
+
+  aws_sqs_queue.my_queue:
+    monthly_requests: 1000000 # Monthly requests to SQS.
+    request_size_kb: 64       # Size of requests to SQS, billed in 64KB chunks. So 1M requests at 128KB uses 2M requests.
+
+  aws_ssm_parameter.my_ssm_parameter:
+    api_throughput_limit: advanced    # SSM Parameter Throughput limit, can be: advanced, higher.
+    monthly_api_interactions: 1000000 # Monthly API interactions.
+    parameter_storage_hrs: 730        # Number of hours in the month parameters will be stored for.
+
+  aws_ssm_activation.my_activations:
+    instance_tier: advanced # Instance tier being used, can be: advanced, standard.
+    instances: 100          # Number of instances being managed.
+
+  aws_vpc_endpoint.my_endpoint:
+    monthly_data_processed_gb: 500 # Monthly data processed by the VPC endpoint(s) in GB.
+
+  aws_vpn_connection.my_connection:
+    monthly_data_processed_gb: 100 # Monthly data processed through a transit gateway attached to your VPN Connection in GB.
+
+  aws_cloudfront_distribution.my_s3_distribution:
+    monthly_data_transfer_to_internet_gb: # Monthly regional data transfer out to internet from the following, in GB:
+      us: 51200000          # United States, Mexico, Canada
+      europe: 220000        # Europe, Israel
+      south_africa: 10000   # South Africa, Kenya, Middle East
+      south_america: 50000  # South America
+      japan: 387000         # Japan
+      australia: 500000     # Australia, New Zealand
+      asia_pacific: 1200000 # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
+      india: 200000         # India
+    monthly_data_transfer_to_origin_gb: # Monthly regional data transfer out to origin from the following, in GB:
+      us: 2200           # United States, Mexico, Canada
+      europe: 1000       # Europe, Israel
+      south_africa: 300  # South Africa, Kenya, Middle East
+      south_america: 200 # South America
+      japan: 10          # Japan
+      australia: 100     # Australia, New Zealand
+      asia_pacific: 30   # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
+      india: 80          # India
+    monthly_http_requests: # Monthly number of HTTP requests to:
+      us: 80000            # United States, Mexico, Canada
+      europe: 40000        # Europe, Israel
+      south_africa: 20000  # South Africa, Kenya, Middle East
+      south_america: 10000 # South America
+      japan: 3000          # Japan
+      australia: 15000     # Australia, New Zealand
+      asia_pacific: 45000  # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
+      india: 10000         # India
+    monthly_https_requests: # Monthly number of HTTPS requests to:
+      us: 180000           # United States, Mexico, Canada
+      europe: 10000        # Europe, Israel
+      south_africa: 50000  # South Africa, Kenya, Middle East
+      south_america: 30000 # South America
+      japan: 1000          # Japan
+      australia: 45000     # Australia, New Zealand
+      asia_pacific: 25000  # Hong Kong, Philippines, Singapore, South Korea, Taiwan, Thailand
+      india: 30000         # India
+    monthly_shield_requests: # Monthly number of shield requests to:
+      us: 90000          # United States
+      europe: 30000      # Europe
+      south_america: 200 # South America
+      japan: 12300       # Japan
+      australia: 2300    # Australia
+      singapore: 58600   # Singapore
+      south_korea: 24000 # South Korea
+      india: 10000       # India
+    monthly_invalidation_requests: 1200 # Monthly number of invalidation requests.
+    monthly_encryption_requests: 100000 # Monthly number of field level encryption requests.
+    monthly_log_lines: 5000000          # Monthly number of real-time log lines.
+    custom_ssl_certificates: 3          # Number of dedicated IP custom SSL certificates.
+
+  aws_autoscaling_group.my_asg:
+    instances: 15 # Number of instances in the autoscaling group.
+  
+  #
+  # Terraform GCP resources
+  #
+  google_cloudfunctions_function.my_function:
+    request_duration_ms: 300               # Average duration of each request in milliseconds.
+    monthly_function_invocations: 10000000 # Monthly number of function invocations.
+    monthly_outbound_data_gb: 100          # Monthly data transferred from the function out to somewhere else in GB.
+
+  google_compute_router_nat.my_nat:
+    assigned_vms: 4                 # Number of VM instances assigned to the NAT gateway
+    monthly_data_processed_gb: 1000 # Monthly data processed (ingress and egress) by the NAT gateway in GB
+
+  google_container_cluster.my_cluster:
+    nodes: 4    # Node count per zone for the default node pool
+    node_pool[0]:
+      nodes: 2  # Node count per zone for the first node pool
+
+  google_container_node_pool.my_node_pool:
+    nodes: 4 # Node count per zone for the node pool
+
+  google_dns_record_set.my_record_set:
+    monthly_queries:  1000000 # Monthly DNS queries.
+
+  google_kms_crypto_key.my_keys:
+    key_versions: 10000             # Number of key versions.
+    monthly_key_operations: 1000000 # Monthly number of key operations.
+
+  google_monitoring_metric_descriptor.my_monitoring:
+    monthly_monitoring_data_mb: 5000 # Monthly monitoring data in MB.
+    monthly_api_calls: 1000000       # Monthly read API calls (write calls are free).
+
+  google_pubsub_subscription.my_subscription:
+    monthly_message_data_tb: 7.416 # Monthly amount of message data pulled by the subscription in TB.
+    storage_gb: 605                # Storage for retaining acknowledged messages in GB.
+    snapshot_storage_gb: 70.6      # Snapshot storage for unacknowledged messages in GB.
+
+  google_pubsub_topic.my_topic:
+    monthly_message_data_tb: 7.416 # Monthly amount of message data published to the topic in TB.
+    
+  google_storage_bucket.my_storage_bucket:
+    storage_gb: 150                   # Total size of bucket in GB.
+    monthly_class_a_operations: 40000 # Monthly number of class A operations (object adds, bucket/object list).
+    monthly_class_b_operations: 20000 # Monthly number of class B operations (object gets, retrieve bucket/object metadata).
+    monthly_data_retrieval_gb: 500    # Monthly amount of data retrieved in GB.
+    monthly_egress_data_transfer_gb:  # Monthly data transfer from Cloud Storage to the following, in GB:
+      same_continent: 550  # Same continent.
+      worldwide: 12500     # Worldwide excluding Asia, Australia.
+      asia: 1500           # Asia excluding China, but including Hong Kong.
+      china: 50            # China excluding Hong Kong.
+      australia: 250       # Australia.


### PR DESCRIPTION
## About #2 
Infracost shows cloud cost estimates for Terraform projects. It helps developers, devops and others to quickly see the cost breakdown and compare different options upfront. https://www.infracost.io/docs/
## Demo CLI installed 👋🏾 
#### Supported resources
The quickest way to find out if your Terraform resources are supported is to run Infracost with the --show-skipped option. This shows the unsupported resources, some of which might be free. You could also run the following command to only see the unsupported resources: infracost --format=json --log-level=warn | jq ".resourceSummary.unsupportedCounts"
Infracost supports the following Terraform resources. We do not take into account free tiers that apply to some resources as it can be difficult to detect which accounts they apply to; you can still see costs going up or down based on changes since we're consistent.
#### Amazon Web Services (AWS) 🚀 
On-demand prices are used. In some cases, AWS Spot prices are also supported, but AWS Reserved Instance prices are not supported since it is difficult to tell from Terraform resources whether they could be utilized.

![image](https://user-images.githubusercontent.com/38333115/110233069-4a682980-7f00-11eb-9407-e0c740ddb9ee.png)

#### Usage methods 🙂 
Infracost can be run with different options depending on the use-case. As mentioned in the FAQ, you can run Infracost in your Terraform directories without worrying about security or privacy issues as no cloud credentials, secrets, tags or Terraform resource identifiers are sent to the open-source Cloud Pricing API. Infracost does not make any changes to your Terraform state or cloud resources. The Cloud Pricing API does not become aware of your cloud spend; it returns price points to the CLI so calculations can be done on your machine.